### PR TITLE
Readme: added namespace to instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The string can be an email, an IP address, a username, an ID or something else.
 Create a new ```Identicon``` object.
 
 ``` php
-$identicon = new Identicon();
+$identicon = new \Identicon\Identicon();
 ```
 
 Then you can generate and display an identicon image


### PR DESCRIPTION
Very simple edit here. I just added the full namespace for the example instantiation in the README.md file because without it the autoloader failed to load the class.
