### PR TITLE
add imagemagick extension as composer dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "fzaninotto/faker": "1.2.*@dev"
+        "fzaninotto/faker": "1.2.*@dev",
+        "ext-imagick": "*"
     },
     "autoload": {
         "psr-0": { "Identicon": "src/" }


### PR DESCRIPTION
added because for development, tests are required and tests doesn't run without imagick extension.
