### PR TITLE
Make SVG output much more compact

### DIFF
--- a/src/Identicon/Generator/SvgGenerator.php
+++ b/src/Identicon/Generator/SvgGenerator.php
@@ -46,25 +46,28 @@ class SvgGenerator extends BaseGenerator implements GeneratorInterface
         // prepare image
         $w = $this->getPixelRatio() * 5;
         $h = $this->getPixelRatio() * 5;
-        $svg = '<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="'.$w.'" height="'.$h.'">';
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="'.$w.'" height="'.$h.'" viewBox="0 0 5 5">';
 
-        $backgroundColor = '#FFFFFF';
+        $backgroundColor = '#FFF';
         $rgbBackgroundColor = $this->getBackgroundColor();
         if (!is_null($rgbBackgroundColor)) {
             $backgroundColor = $this->_toUnderstandableColor($rgbBackgroundColor);
         }
-        $svg .= '<rect width="'.$w.'" height="'.$h.'" style="fill:'.$backgroundColor.';stroke-width:1;stroke:'.$backgroundColor.'"/>';
 
-        $rgbColor = $this->_toUnderstandableColor($this->getColor());
+        $svg .= '<rect width="5" height="5" fill="'.$backgroundColor.'" stroke-width="0"/>';
+
+        $rects = [];
         // draw content
         foreach ($this->getArrayOfSquare() as $lineKey => $lineValue) {
             foreach ($lineValue as $colKey => $colValue) {
                 if (true === $colValue) {
-                    $svg .= '<rect x="'.$colKey * $this->getPixelRatio().'" y="'.$lineKey * $this->getPixelRatio().'" width="'.($this->getPixelRatio()).'" height="'.$this->getPixelRatio().'" style="fill:'.$rgbColor.';stroke-width:0;"/>';
+                    $rects[] = 'M'.$colKey.','.$lineKey.'h1v1h-1v-1';
                 }
             }
         }
 
+        $rgbColor = $this->_toUnderstandableColor($this->getColor());
+        $svg .= '<path fill="'.$rgbColor.'" stroke-width="0" d="' . implode('', $rects) . '"/>';
         $svg .= '</svg>';
 
         $this->generatedImage = $svg;
@@ -80,7 +83,7 @@ class SvgGenerator extends BaseGenerator implements GeneratorInterface
     protected function _toUnderstandableColor($color)
     {
         if (is_array($color)) {
-            return 'rgb('.implode(', ', $color).')';
+            return sprintf('#%X%X%X', $color[0], $color[1], $color[2]);
         }
 
         return $color;

--- a/tests/Identicon/Tests/IdenticonTest.php
+++ b/tests/Identicon/Tests/IdenticonTest.php
@@ -3,6 +3,7 @@
 namespace Identicon\Tests;
 
 use Identicon\Generator\ImageMagickGenerator;
+use Identicon\Generator\SvgGenerator;
 use Identicon\Identicon;
 
 /**
@@ -55,6 +56,30 @@ class IdenticonTest extends \PHPUnit_Framework_TestCase
             ['8.8.4.4', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEEAAABBAQMAAAC0OVsGAAAABlBMVEUAAABg8OBZBnEqAAAAAXRSTlMAQObYZgAAAAlwSFlzAAAASAAAAEgARslrPgAAADJJREFUKM9j+P+HAQj4/zcwDDxroADQBfb/YW4ZGBYUAMOA/f8Dxv8/QM6iNwsIBpAFAJTD5znOXx4GAAAAAElFTkSuQmCC'],
             ['yzalis', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEEAAABBAQMAAAC0OVsGAAAABlBMVEUAAADgwJA3cC1lAAAAAXRSTlMAQObYZgAAAAlwSFlzAAAASAAAAEgARslrPgAAADFJREFUKM9jYGD/DwQ/GIBg4FkMDPb/GRjozvoPBQ0g1gPGgWX9AbmIn/4s5DAYCBYAaeRVTUt0KIYAAAAASUVORK5CYII='],
             ['benjaminAtYzalisDotCom', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEEAAABBAQMAAAC0OVsGAAAABlBMVEUAAABgsDAvrOz7AAAAAXRSTlMAQObYZgAAAAlwSFlzAAAASAAAAEgARslrPgAAADlJREFUKM9jYGD//4Dx/w8GIBgg1n8oaGD4/4fB/j8DP/1ZCBf8B7lqQFhQFwDDBQigIURH1oDHAgCNSlrmMVCO8AAAAABJRU5ErkJggg=='],
+        ];
+    }
+
+    /**
+     * @dataProvider svgResultDataProvider
+     */
+    public function testSvgResult($string, $imageData)
+    {
+        $this->identicon->setGenerator(new SvgGenerator());
+        $this->assertEquals($imageData, $this->identicon->getImageData($string));
+    }
+
+    public function svgResultDataProvider()
+    {
+        return [
+            ['Benjamin', '<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="65" height="65" viewBox="0 0 5 5"><rect width="5" height="5" fill="#FFF" stroke-width="0"/><path fill="#804080" stroke-width="0" d="M0,0h1v1h-1v-1M2,0h1v1h-1v-1M4,0h1v1h-1v-1M1,1h1v1h-1v-1M2,1h1v1h-1v-1M3,1h1v1h-1v-1M0,2h1v1h-1v-1M1,2h1v1h-1v-1M3,2h1v1h-1v-1M4,2h1v1h-1v-1M0,3h1v1h-1v-1M1,3h1v1h-1v-1M2,3h1v1h-1v-1M3,3h1v1h-1v-1M4,3h1v1h-1v-1M0,4h1v1h-1v-1M1,4h1v1h-1v-1M3,4h1v1h-1v-1M4,4h1v1h-1v-1M0,5h1v1h-1v-1M4,5h1v1h-1v-1"/></svg>'],
+
+            ['8.8.8.8', '<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="65" height="65" viewBox="0 0 5 5"><rect width="5" height="5" fill="#FFF" stroke-width="0"/><path fill="#B09040" stroke-width="0" d="M1,0h1v1h-1v-1M3,0h1v1h-1v-1M0,1h1v1h-1v-1M1,1h1v1h-1v-1M3,1h1v1h-1v-1M4,1h1v1h-1v-1M0,2h1v1h-1v-1M1,2h1v1h-1v-1M3,2h1v1h-1v-1M4,2h1v1h-1v-1M0,3h1v1h-1v-1M2,3h1v1h-1v-1M4,3h1v1h-1v-1M2,4h1v1h-1v-1M0,5h1v1h-1v-1M4,5h1v1h-1v-1"/></svg>'],
+
+            ['8.8.4.4', '<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="65" height="65" viewBox="0 0 5 5"><rect width="5" height="5" fill="#FFF" stroke-width="0"/><path fill="#60F0E0" stroke-width="0" d="M0,0h1v1h-1v-1M4,0h1v1h-1v-1M0,2h1v1h-1v-1M2,2h1v1h-1v-1M4,2h1v1h-1v-1M1,3h1v1h-1v-1M3,3h1v1h-1v-1M1,4h1v1h-1v-1M2,4h1v1h-1v-1M3,4h1v1h-1v-1M0,5h1v1h-1v-1M4,5h1v1h-1v-1"/></svg>'],
+
+            ['yzalis', '<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="65" height="65" viewBox="0 0 5 5"><rect width="5" height="5" fill="#FFF" stroke-width="0"/><path fill="#E0C090" stroke-width="0" d="M1,0h1v1h-1v-1M2,0h1v1h-1v-1M3,0h1v1h-1v-1M2,1h1v1h-1v-1M0,2h1v1h-1v-1M1,2h1v1h-1v-1M3,2h1v1h-1v-1M4,2h1v1h-1v-1M0,3h1v1h-1v-1M4,3h1v1h-1v-1M0,4h1v1h-1v-1M1,4h1v1h-1v-1M2,4h1v1h-1v-1M3,4h1v1h-1v-1M4,4h1v1h-1v-1M0,5h1v1h-1v-1M4,5h1v1h-1v-1"/></svg>'],
+
+            ['benjaminAtYzalisDotCom', '<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="65" height="65" viewBox="0 0 5 5"><rect width="5" height="5" fill="#FFF" stroke-width="0"/><path fill="#60B030" stroke-width="0" d="M1,0h1v1h-1v-1M3,0h1v1h-1v-1M0,1h1v1h-1v-1M2,1h1v1h-1v-1M4,1h1v1h-1v-1M0,2h1v1h-1v-1M1,2h1v1h-1v-1M3,2h1v1h-1v-1M4,2h1v1h-1v-1M1,3h1v1h-1v-1M2,3h1v1h-1v-1M3,3h1v1h-1v-1M0,4h1v1h-1v-1M2,4h1v1h-1v-1M4,4h1v1h-1v-1M0,5h1v1h-1v-1M4,5h1v1h-1v-1"/></svg>'],
         ];
     }
 }


### PR DESCRIPTION
Hi, I was somewhat surprised by the large size of the svg-output. It was easily 1600 bytes while png is normally below 300 bytes.

There where also a few bugs; the color-array has more than 3 bytes and was converted into an invalid color. And the separate rectangles can cause glitches (small lines of the background color between some of the rects) when scaling of the image and the screen don't perfectly match.

I converted all rect's into a single path-element, which is much more compact. By defining a viewBox of only 5x5 a rectangle could be converted into these instructions: 'move to x,y coordinates draw a line 1 horizontal, 1 vertical, -1 horizontal, -1 vertical'
Which in svg is written like so: 'M 1,1 h 1 v 1 h -1 v -1', and all those spaces are optional.

With all these changes a svg-image is still a bit larger than the equal png, but is now reduced to 400-500 bytes.

It could be optimized even more, since most boxes don't need all 4 sides specified and lines can be longer than a single position... With an optimal path-element it would probably be around 200-300 bytes.
But the algorithm/code for that is quite a bit more complex than its now :)